### PR TITLE
Added bandaid fix for appointment viewing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -12,7 +12,6 @@ import {
   Instructor,
 } from "./models/index.js";
 import cors from "cors";
-import { Op } from "sequelize";
 
 const app = express();
 const PORT = process.env.PORT || 5090;
@@ -242,8 +241,7 @@ app.post("/api/logout", (req, res) => {
 });
 
 app.get("/api/my-appointments", async (req, res) => {
-  const userId = req.session.user;
-  console.log(req.session);
+  const userId = req.session.user.userId;
   try {
     let appointments;
 


### PR DESCRIPTION
For some reason, on line 244 in server.js, the userId variable was set to "req.session.userId", when it should have been "req.session.user.userId".

It will now display correctly, but only if you manually log out and then log back in before selecting the profile page.